### PR TITLE
fix(deps): update pdf-extract 0.7 -> 0.8 to fix PDF parsing crashes (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 | Version | Date | Type | Description |
 |---------|------|------|-------------|
+| [0.3.3](#033---2026-06-18) | 2026-06-18 | **Bugfix** | Update pdf-extract 0.7 → 0.8 to fix PDF parsing crashes |
 | [0.3.2](#032---2026-02-28) | 2026-02-28 | **Bugfix** | Fix duplicate resource & docling-ffi build errors |
 | [0.3.1](#031---2025-12-06) | 2025-12-06 | **Bugfix** | Fix UTF-8 boundary panic in PDF conversion |
 | [0.3.0](#030---2025-12-06) | 2025-12-06 | **Performance** | PDF memory optimization, cached regex |
@@ -18,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | [0.1.2](#012---2025-10-13) | 2025-10-13 | **Major** | 27 formats, Phase 3 complete, Audio/Video transcription |
 | [0.1.1](#011---2025-10-13) | 2025-10-13 | **Distribution** | MSI installer, icons, automated scripts |
 | [0.1.0](#010---2025-10-13) | 2025-10-13 | **Initial** | Core PDF/DOCX conversion, 98x faster than Docling |
+
+---
+
+## [0.3.3] - 2026-06-18
+
+**Bugfix Release**
+
+Updates the `pdf-extract` dependency to fix application crashes when parsing certain PDF files.
+
+### Fixed
+
+- **Application Crash on Some PDFs** ([#4](https://github.com/hivellm/transmutation/issues/4)): Certain PDF files caused the application to crash during parsing with `pdf-extract` 0.7.x. Bumped `pdf-extract` from `0.7` to `0.8`, which resolves the upstream parsing bugs. The extraction API (`extract_text`, `extract_text_from_mem`) is unchanged, so no source changes were required.
+
+### Changed
+
+- `pdf-extract` dependency updated from `0.7` to `0.8` (resolves to 0.8.2)
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "transmutation"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["HiveLLM Team <team@hivellm.org>"]
 license = "MIT"
@@ -93,7 +93,7 @@ rstar = { version = "0.12", optional = true }
 # Document parsing - Core formats (always enabled)
 # PDF
 lopdf = "0.35"
-pdf-extract = "0.7"
+pdf-extract = "0.8"
 pdfium-render = { version = "0.8", optional = true }  # Only for PDF rendering to images
 
 # HTML/XML


### PR DESCRIPTION
## Description
Certain PDF files caused the application to crash during parsing with `pdf-extract` 0.7.x. This bumps `pdf-extract` to `0.8` (resolves to 0.8.2), which fixes the upstream parsing bugs. The extraction API (`extract_text`, `extract_text_from_mem`) is unchanged, so no source changes were needed. Also bumps the crate version to 0.3.3 and updates the CHANGELOG.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issue
Fixes #4

## Changes Made
- Updated `pdf-extract` dependency from `0.7` to `0.8` (resolves to 0.8.2) in `Cargo.toml`
- Bumped crate version from `0.3.2` to `0.3.3`
- Added a `0.3.3` bugfix entry to `CHANGELOG.md`

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Benchmarks run (if performance-related)

Verified locally:
- `cargo build` succeeds with `pdf-extract` 0.8.2 — no API changes required.
- Full test suite passes (`88 passed; 0 failed`).
- Manually re-ran the `test_pdf_extract` example against `data/1706.03762v7.pdf`; the PDF parses and extracts text without crashing.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact
- Conversion speed: No measurable change (dependency-only update)
- Memory usage: No measurable change
- Binary size: Negligible change

## Additional Notes
This is a dependency-only fix — no source code changes. `pdf-extract` 0.10.0 is also available, but this PR stays within the requested 0.8.x line for a minimal, low-risk update. Note: the extraction example still prints upstream `Unicode mismatch` / `missing char` warnings from `pdf-extract`, which are non-fatal and unrelated to the crash.